### PR TITLE
Expose as an AMD module if AMD loader (like requireJS) is present

### DIFF
--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -251,3 +251,7 @@ Sanitize.prototype.clean_node = function(container) {
   return fragment;
   
 };
+
+if ( typeof define === "function" ) {
+  define( "sanitize", [], function () { return Sanitize; } );
+}


### PR DESCRIPTION
This is the same approach used by jQuery to make this usable in AMD-loaders like requirejs. Without this change, this library can't be optimized in a requirejs build process.

See the very bottom of this file to see the jquery version of this change: http://code.jquery.com/jquery-1.9.1.js

I verified that all tests still pass. Let me know if there anything else I can do.

Thanks,
Ben
