### PR TITLE
Fix a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ configuration:
             a: { href: ['http', 'https', 'mailto'] }
         }
     });
-    s.clean(p);
+    s.clean_node(p);
 
 
 #### add_attributes (Object)


### PR DESCRIPTION
From s.clean(p) to s.clean_node(p)
