### PR TITLE
Changed deprecated nodeValue to value

### DIFF
--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -152,7 +152,7 @@ Sanitize.prototype.clean_node = function(container) {
             // Check protocol attributes for valid protocol
             if(this.config.protocols[name] && this.config.protocols[name][attr_name]) {
               protocols = this.config.protocols[name][attr_name];
-              del = attr.nodeValue.toLowerCase().match(Sanitize.REGEX_PROTOCOL);
+              del = attr.value.toLowerCase().match(Sanitize.REGEX_PROTOCOL);
               if(del) {
                 attr_ok = (_array_index(del[1], protocols) != -1);
               }
@@ -162,7 +162,7 @@ Sanitize.prototype.clean_node = function(container) {
             }
             if(attr_ok) {
               attr_node = document.createAttribute(attr_name);
-              attr_node.value = attr.nodeValue;
+              attr_node.value = attr.value;
               this.current_element.setAttributeNode(attr_node);
             }
         }


### PR DESCRIPTION
Chrome showed console warnings that `nodeValue` is deprecated, so I changed it to `value` as they suggested.
