### PR TITLE
Sanitize css values

### DIFF
--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -21,34 +21,43 @@
  */
 
 function Sanitize(){
-  var i, e, options;
-  options = arguments[0] || {};
-  this.config = {};
-  this.config.elements = options.elements ? options.elements : [];
-  this.config.attributes = options.attributes ? options.attributes : {};
-  this.config.attributes[Sanitize.ALL] = this.config.attributes[Sanitize.ALL] ? this.config.attributes[Sanitize.ALL] : [];
-  this.config.allow_comments = options.allow_comments ? options.allow_comments : false;
-  this.allowed_elements = {};
-  this.config.protocols = options.protocols ? options.protocols : {};
-  this.config.add_attributes = options.add_attributes ? options.add_attributes  : {};
-  this.dom = options.dom ? options.dom : document;
-  for(i=0;i<this.config.elements.length;i++) {
-    this.allowed_elements[this.config.elements[i]] = true;
-  }
-  this.config.remove_element_contents = {};
-  this.config.remove_all_contents = false;
-  if(options.remove_contents) {
-    
-    if(options.remove_contents instanceof Array) {
-      for(i=0;i<options.remove_contents.length;i++) {
-        this.config.remove_element_contents[options.remove_contents[i]] = true;
-      }
+    var i, e, options;
+    options = arguments[0] || {};
+    this.config = {};
+    this.config.elements = options.elements ? options.elements : [];
+    this.config.attributes = options.attributes ? options.attributes : {};
+    this.config.attributes[Sanitize.ALL] = this.config.attributes[Sanitize.ALL] ? this.config.attributes[Sanitize.ALL] : [];
+    this.config.allow_comments = options.allow_comments ? options.allow_comments : false;
+    this.allowed_elements = {};
+    this.config.protocols = options.protocols ? options.protocols : {};
+    //allowed styles
+    this.config.styles = options.styles ? options.styles : [];
+    this.config.cssValues = options.cssValues ? options.cssValues : {};
+
+    //add the rgb counterparts to colors
+    this.hexToRgb(this.config.cssValues.color);
+    //add the rgb counterparts to background colors
+    this.hexToRgb(this.config.cssValues.backgroundColor);
+
+    this.config.add_attributes = options.add_attributes ? options.add_attributes  : {};
+    this.dom = options.dom ? options.dom : document;
+    for(i=0;i<this.config.elements.length;i++) {
+        this.allowed_elements[this.config.elements[i]] = true;
     }
-    else {
-      this.config.remove_all_contents = true;
+    this.config.remove_element_contents = {};
+    this.config.remove_all_contents = false;
+    if(options.remove_contents) {
+
+        if(options.remove_contents instanceof Array) {
+            for(i=0;i<options.remove_contents.length;i++) {
+                this.config.remove_element_contents[options.remove_contents[i]] = true;
+            }
+        }
+        else {
+            this.config.remove_all_contents = true;
+        }
     }
-  }
-  this.transformers = options.transformers ? options.transformers : [];
+    this.transformers = options.transformers ? options.transformers : [];
 }
 
 Sanitize.REGEX_PROTOCOL = /^([A-Za-z0-9\+\-\.\&\;\*\s]*?)(?:\:|&*0*58|&*x0*3a)/i;
@@ -57,204 +66,246 @@ Sanitize.REGEX_PROTOCOL = /^([A-Za-z0-9\+\-\.\&\;\*\s]*?)(?:\:|&*0*58|&*x0*3a)/i
 Sanitize.RELATIVE = '__RELATIVE__';
 Sanitize.ALL = '__ALL__';
 
+Sanitize.prototype.hexToRgb = function(colorList) {
+    if(colorList) {
+        for(var i = 0; i < colorList.length; i++) {
+            var result = /^#([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(colorList[i]);
+            if(result) {
+                colorList.push("rgb(" + parseInt(result[1], 16) + ", " + parseInt(result[2], 16) + ", " + parseInt(result[3], 16) + ")");
+            }
+        }
+    }
+};
+
 Sanitize.prototype.clean_node = function(container) {
-  var fragment = this.dom.createDocumentFragment();
-  this.current_element = fragment;
-  this.whitelist_nodes = [];
+    var fragment = this.dom.createDocumentFragment();
+    this.current_element = fragment;
+    this.whitelist_nodes = [];
 
-  
 
-  /**
-   * Utility function to check if an element exists in an array
-   */
-  function _array_index(needle, haystack) {
-    var i;
-    for(i=0; i < haystack.length; i++) {
-      if(haystack[i] == needle) 
-        return i;
-    }
-    return -1;
-  }
-  
-  function _merge_arrays_uniq() {
-    var result = [];
-    var uniq_hash = {};
-    var i,j;
-    for(i=0;i<arguments.length;i++) {
-      if(!arguments[i] || !arguments[i].length)
-        continue;
-      for(j=0;j<arguments[i].length;j++) {
-        if(uniq_hash[arguments[i][j]])
-          continue;
-        uniq_hash[arguments[i][j]] = true;
-        result.push(arguments[i][j]);
-      }
-    }
-    return result;
-  }
-  
-  /**
-   * Clean function that checks the different node types and cleans them up accordingly
-   * @param elem DOM Node to clean
-   */
-  function _clean(elem) {
-    var clone;
-    switch(elem.nodeType) {
-      // Element
-      case 1:
-        _clean_element.call(this, elem);
-        break;
-      // Text
-      case 3:
-        clone = elem.cloneNode(false);
-        this.current_element.appendChild(clone);
-        break;
-      // Entity-Reference (normally not used)
-      case 5:
-        clone = elem.cloneNode(false);
-        this.current_element.appendChild(clone);
-        break;
-      // Comment
-      case 8:
-        if(this.config.allow_comments) {
-          clone = elem.cloneNode(false);
-          this.current_element.appendChild(clone);
+
+    /**
+     * Utility function to check if an element exists in an array
+     */
+    function _array_index(needle, haystack) {
+        var i;
+        for(i=0; i < haystack.length; i++) {
+            if(haystack[i] == needle)
+                return i;
         }
-        break;
-      default:
-        if (console && console.log) console.log("unknown node type", elem.nodeType);
-        break;
-    }
- 
-  }
-  
-  function _clean_element(elem) {
-    var i, j, clone, parent_element, name, allowed_attributes, attr, attr_name, attr_node, protocols, del, attr_ok;
-    var transform = _transform_element.call(this, elem);
-    
-    elem = transform.node;
-    name = elem.nodeName.toLowerCase();
-    
-    // check if element itself is allowed
-    parent_element = this.current_element;
-    if(this.allowed_elements[name] || transform.whitelist) {
-        this.current_element = this.dom.createElement(elem.nodeName);
-        parent_element.appendChild(this.current_element);
-        
-      // clean attributes
-      var attrs = this.config.attributes;
-      allowed_attributes = _merge_arrays_uniq(attrs[name], attrs[Sanitize.ALL], transform.attr_whitelist);
-      for(i=0;i<allowed_attributes.length;i++) {
-        attr_name = allowed_attributes[i];
-        attr = elem.attributes[attr_name];
-        if(attr) {
-            attr_ok = true;
-            // Check protocol attributes for valid protocol
-            if(this.config.protocols[name] && this.config.protocols[name][attr_name]) {
-              protocols = this.config.protocols[name][attr_name];
-              del = attr.value.toLowerCase().match(Sanitize.REGEX_PROTOCOL);
-              if(del) {
-                attr_ok = (_array_index(del[1], protocols) != -1);
-              }
-              else {
-                attr_ok = (_array_index(Sanitize.RELATIVE, protocols) != -1);
-              }
-            }
-            if(attr_ok) {
-              attr_node = document.createAttribute(attr_name);
-              attr_node.value = attr.value;
-              this.current_element.setAttributeNode(attr_node);
-            }
-        }
-      }
-      
-      // Add attributes
-      if(this.config.add_attributes[name]) {
-        for(attr_name in this.config.add_attributes[name]) {
-          attr_node = document.createAttribute(attr_name);
-          attr_node.value = this.config.add_attributes[name][attr_name];
-          this.current_element.setAttributeNode(attr_node);
-        }
-      }
-    } // End checking if element is allowed
-    // If this node is in the dynamic whitelist array (built at runtime by
-    // transformers), let it live with all of its attributes intact.
-    else if(_array_index(elem, this.whitelist_nodes) != -1) {
-      this.current_element = elem.cloneNode(true);
-      // Remove child nodes, they will be sanitiazied and added by other code
-      while(this.current_element.childNodes.length > 0) {
-        this.current_element.removeChild(this.current_element.firstChild);
-      }
-      parent_element.appendChild(this.current_element);
+        return -1;
     }
 
-    // iterate over child nodes
-    if(!this.config.remove_all_contents && !this.config.remove_element_contents[name]) {
-      for(i=0;i<elem.childNodes.length;i++) {
-        _clean.call(this, elem.childNodes[i]);
-      }
-    }
-    
-    // some versions of IE don't support normalize.
-    if(this.current_element.normalize) {
-      this.current_element.normalize();
-    }
-    this.current_element = parent_element;
-  } // END clean_element function
-  
-  function _transform_element(node) {
-    var output = {
-      attr_whitelist:[],
-      node: node,
-      whitelist: false
-    };
-    var i, j, transform;
-    for(i=0;i<this.transformers.length;i++) {
-      transform = this.transformers[i]({
-        allowed_elements: this.allowed_elements,
-        config: this.config,
-        node: node,
-        node_name: node.nodeName.toLowerCase(),
-        whitelist_nodes: this.whitelist_nodes,
-        dom: this.dom
-      });
-      if (transform == null) 
-        continue;
-      else if(typeof transform == 'object') {
-        if(transform.whitelist_nodes && transform.whitelist_nodes instanceof Array) {
-          for(j=0;j<transform.whitelist_nodes.length;j++) {
-            if(_array_index(transform.whitelist_nodes[j], this.whitelist_nodes) == -1) {
-              this.whitelist_nodes.push(transform.whitelist_nodes[j]);
+    function _merge_arrays_uniq() {
+        var result = [];
+        var uniq_hash = {};
+        var i,j;
+        for(i=0;i<arguments.length;i++) {
+            if(!arguments[i] || !arguments[i].length)
+                continue;
+            for(j=0;j<arguments[i].length;j++) {
+                if(uniq_hash[arguments[i][j]])
+                    continue;
+                uniq_hash[arguments[i][j]] = true;
+                result.push(arguments[i][j]);
             }
-          }
         }
-        output.whitelist = transform.whitelist ? true : false;
-        if(transform.attr_whitelist) {
-          output.attr_whitelist = _merge_arrays_uniq(output.attr_whitelist, transform.attr_whitelist);
-        }
-        output.node = transform.node ? transform.node : output.node;
-      }
-      else {
-        throw new Error("transformer output must be an object or null");
-      }
+        return result;
     }
-    return output;
-  }
-  
-  
-  
-  for(i=0;i<container.childNodes.length;i++) {
-    _clean.call(this, container.childNodes[i]);
-  }
-  
-  if(fragment.normalize) {
-    fragment.normalize();
-  }
-  
-  return fragment;
-  
+
+    /**
+     * Clean function that checks the different node types and cleans them up accordingly
+     * @param elem DOM Node to clean
+     */
+    function _clean(elem) {
+        var clone;
+        switch(elem.nodeType) {
+            // Element
+            case 1:
+                _clean_element.call(this, elem);
+                break;
+            // Text
+            case 3:
+                clone = elem.cloneNode(false);
+                this.current_element.appendChild(clone);
+                break;
+            // Entity-Reference (normally not used)
+            case 5:
+                clone = elem.cloneNode(false);
+                this.current_element.appendChild(clone);
+                break;
+            // Comment
+            case 8:
+                if(this.config.allow_comments) {
+                    clone = elem.cloneNode(false);
+                    this.current_element.appendChild(clone);
+                }
+                break;
+            default:
+                if (console && console.log) console.log("unknown node type", elem.nodeType);
+                break;
+        }
+
+    }
+
+    function _clean_element(elem) {
+        var i, j, clone, parent_element, name, allowed_attributes, attr, attr_name, attr_node, protocols, del, attr_ok;
+        var transform = _transform_element.call(this, elem);
+
+        elem = transform.node;
+        name = elem.nodeName.toLowerCase();
+
+        // check if element itself is allowed
+        parent_element = this.current_element;
+        if(this.allowed_elements[name] || transform.whitelist) {
+            this.current_element = this.dom.createElement(elem.nodeName);
+            parent_element.appendChild(this.current_element);
+
+            // clean attributes
+            var attrs = this.config.attributes;
+            allowed_attributes = _merge_arrays_uniq(attrs[name], attrs[Sanitize.ALL], transform.attr_whitelist);
+            for(i=0;i<allowed_attributes.length;i++) {
+                attr_name = allowed_attributes[i];
+                attr = elem.attributes[attr_name];
+                if(attr) {
+                    attr_ok = true;
+                    // Check protocol attributes for valid protocol
+                    if(this.config.protocols[name] && this.config.protocols[name][attr_name]) {
+                        protocols = this.config.protocols[name][attr_name];
+                        del = attr.value.toLowerCase().match(Sanitize.REGEX_PROTOCOL);
+                        if(del) {
+                            attr_ok = (_array_index(del[1], protocols) != -1);
+                        }
+                        else {
+                            attr_ok = (_array_index(Sanitize.RELATIVE, protocols) != -1);
+                        }
+                    }
+
+                    // Check style attributes for valid style
+                    if(attr_name == "style") {
+                        var resultStyle = '';
+                        for(var index in Object.keys(elem.style)) {
+                            var styleName = elem.style[index];
+                            //"text-decoration-line" should actually be "text-decoration"
+                            if(styleName == "text-decoration-line") {
+                                styleName = "text-decoration";
+                            }
+                            //we only need to see if the style is white-listed if the element has that style
+                            if(elem.style.hasOwnProperty(index) && this.config.styles.indexOf(styleName) != -1) {
+                                //get rid of the "" and '' that sometimes surround the style values
+                                var styleValue = elem.style[styleName].trim().toLowerCase().replace(/['"]+/g, '');
+                                //check to see if we allow the color
+                                if(styleName == "color" && this.config.cssValues.color.indexOf(styleValue) == -1) {
+                                    resultStyle += "color: #000000;";
+                                } else if(styleName == "background-color" && this.config.cssValues.backgroundColor.indexOf(styleValue) == -1) {
+                                    resultStyle += "background-color: #ffffff;";
+                                } else if(styleName == "font-family" && this.config.cssValues.fontFamily.indexOf(styleValue) == -1) {
+                                    resultStyle += "font-family: Arial;";
+                                } else if(styleName == "font-size" && this.config.cssValues.fontSize.indexOf(styleValue) == -1) {
+                                    resultStyle += "font-size: 10pt;";
+                                } else {
+                                    resultStyle += (styleName + ': ' + elem.style[styleName] + ';');
+                                }
+                            }
+                        }
+                        attr.value = resultStyle;
+                    }
+
+                    if(attr_ok) {
+                        attr_node = document.createAttribute(attr_name);
+                        attr_node.value = attr.value;
+                        this.current_element.setAttributeNode(attr_node);
+                    }
+                }
+            }
+
+            // Add attributes
+            if(this.config.add_attributes[name]) {
+                for(attr_name in this.config.add_attributes[name]) {
+                    attr_node = document.createAttribute(attr_name);
+                    attr_node.value = this.config.add_attributes[name][attr_name];
+                    this.current_element.setAttributeNode(attr_node);
+                }
+            }
+        } // End checking if element is allowed
+        // If this node is in the dynamic whitelist array (built at runtime by
+        // transformers), let it live with all of its attributes intact.
+        else if(_array_index(elem, this.whitelist_nodes) != -1) {
+            this.current_element = elem.cloneNode(true);
+            // Remove child nodes, they will be sanitiazied and added by other code
+            while(this.current_element.childNodes.length > 0) {
+                this.current_element.removeChild(this.current_element.firstChild);
+            }
+            parent_element.appendChild(this.current_element);
+        }
+
+        // iterate over child nodes
+        if(!this.config.remove_all_contents && !this.config.remove_element_contents[name]) {
+            for(i=0;i<elem.childNodes.length;i++) {
+                _clean.call(this, elem.childNodes[i]);
+            }
+        }
+
+        // some versions of IE don't support normalize.
+        if(this.current_element.normalize) {
+            this.current_element.normalize();
+        }
+        this.current_element = parent_element;
+    } // END clean_element function
+
+    function _transform_element(node) {
+        var output = {
+            attr_whitelist:[],
+            node: node,
+            whitelist: false
+        };
+        var i, j, transform;
+        for(i=0;i<this.transformers.length;i++) {
+            transform = this.transformers[i]({
+                allowed_elements: this.allowed_elements,
+                config: this.config,
+                node: node,
+                node_name: node.nodeName.toLowerCase(),
+                whitelist_nodes: this.whitelist_nodes,
+                dom: this.dom
+            });
+            if (transform == null)
+                continue;
+            else if(typeof transform == 'object') {
+                if(transform.whitelist_nodes && transform.whitelist_nodes instanceof Array) {
+                    for(j=0;j<transform.whitelist_nodes.length;j++) {
+                        if(_array_index(transform.whitelist_nodes[j], this.whitelist_nodes) == -1) {
+                            this.whitelist_nodes.push(transform.whitelist_nodes[j]);
+                        }
+                    }
+                }
+                output.whitelist = transform.whitelist ? true : false;
+                if(transform.attr_whitelist) {
+                    output.attr_whitelist = _merge_arrays_uniq(output.attr_whitelist, transform.attr_whitelist);
+                }
+                output.node = transform.node ? transform.node : output.node;
+            }
+            else {
+                throw new Error("transformer output must be an object or null");
+            }
+        }
+        return output;
+    }
+
+
+
+    for(i=0;i<container.childNodes.length;i++) {
+        _clean.call(this, container.childNodes[i]);
+    }
+
+    if(fragment.normalize) {
+        fragment.normalize();
+    }
+
+    return fragment;
+
 };
 
 if ( typeof define === "function" ) {
-  define( "sanitize", [], function () { return Sanitize; } );
+    define( "sanitize", [], function () { return Sanitize; } );
 }

--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -21,43 +21,43 @@
  */
 
 function Sanitize(){
-    var i, e, options;
-    options = arguments[0] || {};
-    this.config = {};
-    this.config.elements = options.elements ? options.elements : [];
-    this.config.attributes = options.attributes ? options.attributes : {};
-    this.config.attributes[Sanitize.ALL] = this.config.attributes[Sanitize.ALL] ? this.config.attributes[Sanitize.ALL] : [];
-    this.config.allow_comments = options.allow_comments ? options.allow_comments : false;
-    this.allowed_elements = {};
-    this.config.protocols = options.protocols ? options.protocols : {};
-    //allowed styles
-    this.config.styles = options.styles ? options.styles : [];
-    this.config.cssValues = options.cssValues ? options.cssValues : {};
+  var i, e, options;
+  options = arguments[0] || {};
+  this.config = {};
+  this.config.elements = options.elements ? options.elements : [];
+  this.config.attributes = options.attributes ? options.attributes : {};
+  this.config.attributes[Sanitize.ALL] = this.config.attributes[Sanitize.ALL] ? this.config.attributes[Sanitize.ALL] : [];
+  this.config.allow_comments = options.allow_comments ? options.allow_comments : false;
+  this.allowed_elements = {};
+  this.config.protocols = options.protocols ? options.protocols : {};
+  //allowed styles
+  this.config.styles = options.styles ? options.styles : [];
+  this.config.cssValues = options.cssValues ? options.cssValues : {};
 
-    //add the rgb counterparts to colors
-    this.hexToRgb(this.config.cssValues.color);
-    //add the rgb counterparts to background colors
-    this.hexToRgb(this.config.cssValues.backgroundColor);
+  //add the rgb counterparts to colors
+  this.hexToRgb(this.config.cssValues.color);
+  //add the rgb counterparts to background colors
+  this.hexToRgb(this.config.cssValues.backgroundColor);
 
-    this.config.add_attributes = options.add_attributes ? options.add_attributes  : {};
-    this.dom = options.dom ? options.dom : document;
-    for(i=0;i<this.config.elements.length;i++) {
-        this.allowed_elements[this.config.elements[i]] = true;
+  this.config.add_attributes = options.add_attributes ? options.add_attributes  : {};
+  this.dom = options.dom ? options.dom : document;
+  for(i=0;i<this.config.elements.length;i++) {
+    this.allowed_elements[this.config.elements[i]] = true;
+  }
+  this.config.remove_element_contents = {};
+  this.config.remove_all_contents = false;
+  if(options.remove_contents) {
+
+    if(options.remove_contents instanceof Array) {
+      for(i=0;i<options.remove_contents.length;i++) {
+        this.config.remove_element_contents[options.remove_contents[i]] = true;
+      }
     }
-    this.config.remove_element_contents = {};
-    this.config.remove_all_contents = false;
-    if(options.remove_contents) {
-
-        if(options.remove_contents instanceof Array) {
-            for(i=0;i<options.remove_contents.length;i++) {
-                this.config.remove_element_contents[options.remove_contents[i]] = true;
-            }
-        }
-        else {
-            this.config.remove_all_contents = true;
-        }
+    else {
+      this.config.remove_all_contents = true;
     }
-    this.transformers = options.transformers ? options.transformers : [];
+  }
+  this.transformers = options.transformers ? options.transformers : [];
 }
 
 Sanitize.REGEX_PROTOCOL = /^([A-Za-z0-9\+\-\.\&\;\*\s]*?)(?:\:|&*0*58|&*x0*3a)/i;
@@ -67,240 +67,238 @@ Sanitize.RELATIVE = '__RELATIVE__';
 Sanitize.ALL = '__ALL__';
 
 Sanitize.prototype.hexToRgb = function(colorList) {
-    if(colorList) {
-        for(var i = 0; i < colorList.length; i++) {
-            var result = /^#([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(colorList[i]);
-            if(result) {
-                colorList.push("rgb(" + parseInt(result[1], 16) + ", " + parseInt(result[2], 16) + ", " + parseInt(result[3], 16) + ")");
-            }
-        }
+  if(colorList) {
+    for(var i = 0; i < colorList.length; i++) {
+      var result = /^#([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(colorList[i]);
+      if(result) {
+        colorList.push("rgb(" + parseInt(result[1], 16) + ", " + parseInt(result[2], 16) + ", " + parseInt(result[3], 16) + ")");
+      }
     }
+  }
 };
 
 Sanitize.prototype.clean_node = function(container) {
-    var fragment = this.dom.createDocumentFragment();
-    this.current_element = fragment;
-    this.whitelist_nodes = [];
+  var fragment = this.dom.createDocumentFragment();
+  this.current_element = fragment;
+  this.whitelist_nodes = [];
 
 
 
-    /**
-     * Utility function to check if an element exists in an array
-     */
-    function _array_index(needle, haystack) {
-        var i;
-        for(i=0; i < haystack.length; i++) {
-            if(haystack[i] == needle)
-                return i;
+  /**
+   * Utility function to check if an element exists in an array
+   */
+  function _array_index(needle, haystack) {
+    var i;
+    for(i=0; i < haystack.length; i++) {
+      if(haystack[i] == needle)
+        return i;
+    }
+    return -1;
+  }
+
+  function _merge_arrays_uniq() {
+    var result = [];
+    var uniq_hash = {};
+    var i,j;
+    for(i=0;i<arguments.length;i++) {
+      if(!arguments[i] || !arguments[i].length)
+        continue;
+      for(j=0;j<arguments[i].length;j++) {
+        if(uniq_hash[arguments[i][j]])
+          continue;
+        uniq_hash[arguments[i][j]] = true;
+        result.push(arguments[i][j]);
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Clean function that checks the different node types and cleans them up accordingly
+   * @param elem DOM Node to clean
+   */
+  function _clean(elem) {
+    var clone;
+    switch(elem.nodeType) {
+      // Element
+      case 1:
+        _clean_element.call(this, elem);
+        break;
+      // Text
+      case 3:
+        clone = elem.cloneNode(false);
+        this.current_element.appendChild(clone);
+        break;
+      // Entity-Reference (normally not used)
+      case 5:
+        clone = elem.cloneNode(false);
+        this.current_element.appendChild(clone);
+        break;
+      // Comment
+      case 8:
+        if(this.config.allow_comments) {
+          clone = elem.cloneNode(false);
+          this.current_element.appendChild(clone);
         }
-        return -1;
+        break;
+      default:
+        if (console && console.log) console.log("unknown node type", elem.nodeType);
+        break;
     }
 
-    function _merge_arrays_uniq() {
-        var result = [];
-        var uniq_hash = {};
-        var i,j;
-        for(i=0;i<arguments.length;i++) {
-            if(!arguments[i] || !arguments[i].length)
-                continue;
-            for(j=0;j<arguments[i].length;j++) {
-                if(uniq_hash[arguments[i][j]])
-                    continue;
-                uniq_hash[arguments[i][j]] = true;
-                result.push(arguments[i][j]);
-            }
-        }
-        return result;
-    }
+  }
 
-    /**
-     * Clean function that checks the different node types and cleans them up accordingly
-     * @param elem DOM Node to clean
-     */
-    function _clean(elem) {
-        var clone;
-        switch(elem.nodeType) {
-            // Element
-            case 1:
-                _clean_element.call(this, elem);
-                break;
-            // Text
-            case 3:
-                clone = elem.cloneNode(false);
-                this.current_element.appendChild(clone);
-                break;
-            // Entity-Reference (normally not used)
-            case 5:
-                clone = elem.cloneNode(false);
-                this.current_element.appendChild(clone);
-                break;
-            // Comment
-            case 8:
-                if(this.config.allow_comments) {
-                    clone = elem.cloneNode(false);
-                    this.current_element.appendChild(clone);
-                }
-                break;
-            default:
-                if (console && console.log) console.log("unknown node type", elem.nodeType);
-                break;
-        }
+  function _clean_element(elem) {
+    var i, j, clone, parent_element, name, allowed_attributes, attr, attr_name, attr_node, protocols, del, attr_ok;
+    var transform = _transform_element.call(this, elem);
 
-    }
+    elem = transform.node;
+    name = elem.nodeName.toLowerCase();
 
-    function _clean_element(elem) {
-        var i, j, clone, parent_element, name, allowed_attributes, attr, attr_name, attr_node, protocols, del, attr_ok;
-        var transform = _transform_element.call(this, elem);
+    // check if element itself is allowed
+    parent_element = this.current_element;
+    if(this.allowed_elements[name] || transform.whitelist) {
+      this.current_element = this.dom.createElement(elem.nodeName);
+      parent_element.appendChild(this.current_element);
 
-        elem = transform.node;
-        name = elem.nodeName.toLowerCase();
-
-        // check if element itself is allowed
-        parent_element = this.current_element;
-        if(this.allowed_elements[name] || transform.whitelist) {
-            this.current_element = this.dom.createElement(elem.nodeName);
-            parent_element.appendChild(this.current_element);
-
-            // clean attributes
-            var attrs = this.config.attributes;
-            allowed_attributes = _merge_arrays_uniq(attrs[name], attrs[Sanitize.ALL], transform.attr_whitelist);
-            for(i=0;i<allowed_attributes.length;i++) {
-                attr_name = allowed_attributes[i];
-                attr = elem.attributes[attr_name];
-                if(attr) {
-                    attr_ok = true;
-                    // Check protocol attributes for valid protocol
-                    if(this.config.protocols[name] && this.config.protocols[name][attr_name]) {
-                        protocols = this.config.protocols[name][attr_name];
-                        del = attr.value.toLowerCase().match(Sanitize.REGEX_PROTOCOL);
-                        if(del) {
-                            attr_ok = (_array_index(del[1], protocols) != -1);
-                        }
-                        else {
-                            attr_ok = (_array_index(Sanitize.RELATIVE, protocols) != -1);
-                        }
-                    }
-
-                    // Check style attributes for valid style
-                    if(attr_name == "style") {
-                        var resultStyle = '';
-                        for(var index in Object.keys(elem.style)) {
-                            var styleName = elem.style[index];
-                            //"text-decoration-line" should actually be "text-decoration"
-                            if(styleName == "text-decoration-line") {
-                                styleName = "text-decoration";
-                            }
-                            //we only need to see if the style is white-listed if the element has that style
-                            if(elem.style.hasOwnProperty(index) && this.config.styles.indexOf(styleName) != -1) {
-                                //get rid of the "" and '' that sometimes surround the style values
-                                var styleValue = elem.style[styleName].trim().toLowerCase().replace(/['"]+/g, '');
-                                //check to see if we allow the style value
-                                if(!(styleName == "color" && this.config.cssValues.color.indexOf(styleValue) == -1 ||
-                                        styleName == "background-color" && this.config.cssValues.backgroundColor.indexOf(styleValue) == -1 ||
-                                        styleName == "font-family" && this.config.cssValues.fontFamily.indexOf(styleValue) == -1 ||
-                                        styleName == "font-size" && this.config.cssValues.fontSize.indexOf(styleValue) == -1)) {
-                                    resultStyle += (styleName + ': ' + elem.style[styleName] + ';');
-                                }
-                            }
-                        }
-                        attr.value = resultStyle;
-                    }
-
-                    if(attr_ok) {
-                        attr_node = document.createAttribute(attr_name);
-                        attr_node.value = attr.value;
-                        this.current_element.setAttributeNode(attr_node);
-                    }
-                }
-            }
-
-            // Add attributes
-            if(this.config.add_attributes[name]) {
-                for(attr_name in this.config.add_attributes[name]) {
-                    attr_node = document.createAttribute(attr_name);
-                    attr_node.value = this.config.add_attributes[name][attr_name];
-                    this.current_element.setAttributeNode(attr_node);
-                }
-            }
-        } // End checking if element is allowed
-        // If this node is in the dynamic whitelist array (built at runtime by
-        // transformers), let it live with all of its attributes intact.
-        else if(_array_index(elem, this.whitelist_nodes) != -1) {
-            this.current_element = elem.cloneNode(true);
-            // Remove child nodes, they will be sanitiazied and added by other code
-            while(this.current_element.childNodes.length > 0) {
-                this.current_element.removeChild(this.current_element.firstChild);
-            }
-            parent_element.appendChild(this.current_element);
-        }
-
-        // iterate over child nodes
-        if(!this.config.remove_all_contents && !this.config.remove_element_contents[name]) {
-            for(i=0;i<elem.childNodes.length;i++) {
-                _clean.call(this, elem.childNodes[i]);
-            }
-        }
-
-        // some versions of IE don't support normalize.
-        if(this.current_element.normalize) {
-            this.current_element.normalize();
-        }
-        this.current_element = parent_element;
-    } // END clean_element function
-
-    function _transform_element(node) {
-        var output = {
-            attr_whitelist:[],
-            node: node,
-            whitelist: false
-        };
-        var i, j, transform;
-        for(i=0;i<this.transformers.length;i++) {
-            transform = this.transformers[i]({
-                allowed_elements: this.allowed_elements,
-                config: this.config,
-                node: node,
-                node_name: node.nodeName.toLowerCase(),
-                whitelist_nodes: this.whitelist_nodes,
-                dom: this.dom
-            });
-            if (transform == null)
-                continue;
-            else if(typeof transform == 'object') {
-                if(transform.whitelist_nodes && transform.whitelist_nodes instanceof Array) {
-                    for(j=0;j<transform.whitelist_nodes.length;j++) {
-                        if(_array_index(transform.whitelist_nodes[j], this.whitelist_nodes) == -1) {
-                            this.whitelist_nodes.push(transform.whitelist_nodes[j]);
-                        }
-                    }
-                }
-                output.whitelist = transform.whitelist ? true : false;
-                if(transform.attr_whitelist) {
-                    output.attr_whitelist = _merge_arrays_uniq(output.attr_whitelist, transform.attr_whitelist);
-                }
-                output.node = transform.node ? transform.node : output.node;
+      // clean attributes
+      var attrs = this.config.attributes;
+      allowed_attributes = _merge_arrays_uniq(attrs[name], attrs[Sanitize.ALL], transform.attr_whitelist);
+      for(i=0;i<allowed_attributes.length;i++) {
+        attr_name = allowed_attributes[i];
+        attr = elem.attributes[attr_name];
+        if(attr) {
+          attr_ok = true;
+          // Check protocol attributes for valid protocol
+          if(this.config.protocols[name] && this.config.protocols[name][attr_name]) {
+            protocols = this.config.protocols[name][attr_name];
+            del = attr.value.toLowerCase().match(Sanitize.REGEX_PROTOCOL);
+            if(del) {
+              attr_ok = (_array_index(del[1], protocols) != -1);
             }
             else {
-                throw new Error("transformer output must be an object or null");
+              attr_ok = (_array_index(Sanitize.RELATIVE, protocols) != -1);
             }
+          }
+
+          // Check style attributes for valid style
+          if(attr_name == "style") {
+            var resultStyle = '';
+            for(var index in Object.keys(elem.style)) {
+              var styleName = elem.style[index];
+              //"text-decoration-line" should actually be "text-decoration"
+              if(styleName == "text-decoration-line") {
+                styleName = "text-decoration";
+              }
+              //we only need to see if the style is white-listed if the element has that style
+              if(elem.style.hasOwnProperty(index) && this.config.styles.indexOf(styleName) != -1) {
+                //get rid of the "" and '' that sometimes surround the style values
+                var styleValue = elem.style[styleName].trim().toLowerCase().replace(/['"]+/g, '');
+                //check to see if we allow the style value
+                if(!(styleName == "color" && this.config.cssValues.color.indexOf(styleValue) == -1 ||
+                    styleName == "background-color" && this.config.cssValues.backgroundColor.indexOf(styleValue) == -1 ||
+                    styleName == "font-family" && this.config.cssValues.fontFamily.indexOf(styleValue) == -1 ||
+                    styleName == "font-size" && this.config.cssValues.fontSize.indexOf(styleValue) == -1)) {
+                  resultStyle += (styleName + ': ' + elem.style[styleName] + ';');
+                }
+              }
+            }
+            attr.value = resultStyle;
+          }
+
+          if(attr_ok) {
+            attr_node = document.createAttribute(attr_name);
+            attr_node.value = attr.value;
+            this.current_element.setAttributeNode(attr_node);
+          }
         }
-        return output;
+      }
+
+      // Add attributes
+      if(this.config.add_attributes[name]) {
+        for(attr_name in this.config.add_attributes[name]) {
+          attr_node = document.createAttribute(attr_name);
+          attr_node.value = this.config.add_attributes[name][attr_name];
+          this.current_element.setAttributeNode(attr_node);
+        }
+      }
+    } // End checking if element is allowed
+    // If this node is in the dynamic whitelist array (built at runtime by
+    // transformers), let it live with all of its attributes intact.
+    else if(_array_index(elem, this.whitelist_nodes) != -1) {
+      this.current_element = elem.cloneNode(true);
+      // Remove child nodes, they will be sanitiazied and added by other code
+      while(this.current_element.childNodes.length > 0) {
+        this.current_element.removeChild(this.current_element.firstChild);
+      }
+      parent_element.appendChild(this.current_element);
     }
 
-
-
-    for(i=0;i<container.childNodes.length;i++) {
-        _clean.call(this, container.childNodes[i]);
+    // iterate over child nodes
+    if(!this.config.remove_all_contents && !this.config.remove_element_contents[name]) {
+      for(i=0;i<elem.childNodes.length;i++) {
+        _clean.call(this, elem.childNodes[i]);
+      }
     }
 
-    if(fragment.normalize) {
-        fragment.normalize();
+    // some versions of IE don't support normalize.
+    if(this.current_element.normalize) {
+      this.current_element.normalize();
     }
+    this.current_element = parent_element;
+  } // END clean_element function
 
-    return fragment;
+  function _transform_element(node) {
+    var output = {
+      attr_whitelist:[],
+      node: node,
+      whitelist: false
+    };
+    var i, j, transform;
+    for(i=0;i<this.transformers.length;i++) {
+      transform = this.transformers[i]({
+        allowed_elements: this.allowed_elements,
+        config: this.config,
+        node: node,
+        node_name: node.nodeName.toLowerCase(),
+        whitelist_nodes: this.whitelist_nodes,
+        dom: this.dom
+      });
+      if (transform == null)
+        continue;
+      else if(typeof transform == 'object') {
+        if(transform.whitelist_nodes && transform.whitelist_nodes instanceof Array) {
+          for(j=0;j<transform.whitelist_nodes.length;j++) {
+            if(_array_index(transform.whitelist_nodes[j], this.whitelist_nodes) == -1) {
+              this.whitelist_nodes.push(transform.whitelist_nodes[j]);
+            }
+          }
+        }
+        output.whitelist = transform.whitelist ? true : false;
+        if(transform.attr_whitelist) {
+          output.attr_whitelist = _merge_arrays_uniq(output.attr_whitelist, transform.attr_whitelist);
+        }
+        output.node = transform.node ? transform.node : output.node;
+      }
+      else {
+        throw new Error("transformer output must be an object or null");
+      }
+    }
+    return output;
+  }
+
+  for(i=0;i<container.childNodes.length;i++) {
+    _clean.call(this, container.childNodes[i]);
+  }
+
+  if(fragment.normalize) {
+    fragment.normalize();
+  }
+
+  return fragment;
 
 };
 
 if ( typeof define === "function" ) {
-    define( "sanitize", [], function () { return Sanitize; } );
+  define( "sanitize", [], function () { return Sanitize; } );
 }

--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -194,16 +194,11 @@ Sanitize.prototype.clean_node = function(container) {
                             if(elem.style.hasOwnProperty(index) && this.config.styles.indexOf(styleName) != -1) {
                                 //get rid of the "" and '' that sometimes surround the style values
                                 var styleValue = elem.style[styleName].trim().toLowerCase().replace(/['"]+/g, '');
-                                //check to see if we allow the color
-                                if(styleName == "color" && this.config.cssValues.color.indexOf(styleValue) == -1) {
-                                    resultStyle += "color: #000000;";
-                                } else if(styleName == "background-color" && this.config.cssValues.backgroundColor.indexOf(styleValue) == -1) {
-                                    resultStyle += "background-color: #ffffff;";
-                                } else if(styleName == "font-family" && this.config.cssValues.fontFamily.indexOf(styleValue) == -1) {
-                                    resultStyle += "font-family: Arial;";
-                                } else if(styleName == "font-size" && this.config.cssValues.fontSize.indexOf(styleValue) == -1) {
-                                    resultStyle += "font-size: 10pt;";
-                                } else {
+                                //check to see if we allow the style value
+                                if(!(styleName == "color" && this.config.cssValues.color.indexOf(styleValue) == -1 ||
+                                        styleName == "background-color" && this.config.cssValues.backgroundColor.indexOf(styleValue) == -1 ||
+                                        styleName == "font-family" && this.config.cssValues.fontFamily.indexOf(styleValue) == -1 ||
+                                        styleName == "font-size" && this.config.cssValues.fontSize.indexOf(styleValue) == -1)) {
                                     resultStyle += (styleName + ': ' + elem.style[styleName] + ';');
                                 }
                             }

--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -287,8 +287,6 @@ Sanitize.prototype.clean_node = function(container) {
         return output;
     }
 
-
-
     for(i=0;i<container.childNodes.length;i++) {
         _clean.call(this, container.childNodes[i]);
     }


### PR DESCRIPTION
Before you could only white-list certain attributes but not their values. I added the ability to specify values you want to white-list in the style attribute to filter out unwanted style values.

You can specify what styles you allow in the 'styles' array and what values you allow in certain style attributes through the 'cssValues' object, such as:
var sanitize = new Sanitize({
        elements: ['a', 'br', 'li', 'ol', 'p', 'ul', 'span'],
        attributes: {
            a: ['data-id', 'href', 'target'],
            span: ['class'],
            '__ALL__': ['style']
        },
        protocols: {
            a: { href: ['http', 'https', 'smartsheet'] }
        },
         styles: ["color", "background-color", "font-family", "font-size"],
        cssValues: {
            color: ["black", "red", "gray", "grey", "yellow", "white"],
            backgroundColor: ["black", "red", "gray", "grey", "yellow", "white"],
            fontFamily:["times new roman", "tahoma", "arial", "verdana"],
            fontSize:["8pt", "9pt", "10pt", "12pt", "14pt", "16pt", "18pt", "20pt", "24pt", "28pt", "32pt", "36pt"]
        }
    });