### PR TITLE
Add package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "sanitize",
+  "version": "1.0.0",
+  "description": "Sanitize.js is a whitelist-based HTML sanitizer",
+  "main": "lib/sanitize.js",
+  "directories": {
+    "example": "examples",
+    "lib": "lib",
+    "test": "test"
+  },
+  "scripts": {
+    "test": "open test/test.html"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gbirke/Sanitize.js.git"
+  },
+  "author": "Gabriel Birke",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gbirke/Sanitize.js/issues"
+  },
+  "homepage": "https://github.com/gbirke/Sanitize.js#readme"
+}


### PR DESCRIPTION
I wanted to include this package as an NPM dependency, but it's not on the NPM registry. I tried to add it as a Github dependency, which NPM supports, but you can't do that without a `package.json`.

I was going to just install it from my fork on Github, but it probably would be useful for other people to have the `package.json` available to them as well.