### PR TITLE
Use setAttribute instead of setAttributeNode

### DIFF
--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -161,9 +161,7 @@ Sanitize.prototype.clean_node = function(container) {
               }
             }
             if(attr_ok) {
-              attr_node = document.createAttribute(attr_name);
-              attr_node.value = attr.value;
-              this.current_element.setAttributeNode(attr_node);
+              this.current_element.setAttribute(attr_name, attr.value);
             }
         }
       }
@@ -171,9 +169,7 @@ Sanitize.prototype.clean_node = function(container) {
       // Add attributes
       if(this.config.add_attributes[name]) {
         for(attr_name in this.config.add_attributes[name]) {
-          attr_node = document.createAttribute(attr_name);
-          attr_node.value = this.config.add_attributes[name][attr_name];
-          this.current_element.setAttributeNode(attr_node);
+          this.current_element.setAttribute(attr_name, this.config.add_attributes[name][attr_name]);
         }
       }
     } // End checking if element is allowed


### PR DESCRIPTION
By author (5 years ago):
--------------------------------------------------------------------------
In some versions of IE setAttributeNode throws the enigmatic "Member not
found" error with particular combinations of element and attribute. For
example calling setAttributeNode on a td with a colspan attr. Go figure :)

I’m not sure why sanitize uses setAttributeNode but setAttribute doesn’t
seem to do any harm, so here we are.
--------------------------------------------------------------------------
Update:
We have been using this fork for years now, and it seems to do little harm. Might as well send this PR so we can clean up!